### PR TITLE
Corect reactivity diagram of rating_bar on spec_doc

### DIFF
--- a/reports/spec_doc.md
+++ b/reports/spec_doc.md
@@ -50,11 +50,12 @@ flowchart TD
   F --> T1([total_bookings])
   F --> T2([total_revenue])
   F --> T3([canceled_bookings])
-  F --> P1([rating_bar])
   F --> P2([line_chart])
   F --> P4([sunburst_chart])
 
   G --> P3([pie_chart])
+  G --> P1([rating_bar])
+
   
   VL --> VS1([vehicle_suffix_bookings])
   VL --> VS2([vehicle_suffix_revenue])


### PR DESCRIPTION
Originally on the reactivity diagram `rating_bar` is dependent on `filtered_data`.
Fixed it, so that `rating_bar` is dependent on `filtered_data_date_only`.